### PR TITLE
Fix multiple choice prompt helper

### DIFF
--- a/r2r/evaluate/eval_utils.py
+++ b/r2r/evaluate/eval_utils.py
@@ -236,7 +236,7 @@ def translate_private_test_cases(encoded_data: str) -> dict[str, str]:
     original_data = pickle.loads(decompressed_data)
     return json.loads(original_data)
 
-def prepare_multiple_choice_prompt(line: dict[str, Any], format_config: dict[str, Any]) -> str:
+def prepare_multiple_choice_prompt(line: dict[str, Any], format_config: dict[str, Any]) -> tuple[str, str]:
     
     options_fields = format_config.get("options_fields", [])
     if len(options_fields) >= 4:  # Need at least 4 options for A, B, C, D
@@ -261,7 +261,7 @@ def prepare_multiple_choice_prompt(line: dict[str, Any], format_config: dict[str
             "D": shuffled_options[3]
         }
         answer = correct_letter
-                
+
         # Format the problem with options
         formatted_problem = QUERY_TEMPLATE_MULTICHOICE.format(
             Question=line[format_config["question_field"]],
@@ -270,5 +270,5 @@ def prepare_multiple_choice_prompt(line: dict[str, Any], format_config: dict[str
             C=options["C"],
             D=options["D"]
         )
-        
-        return formatted_problem
+
+        return formatted_problem, answer

--- a/script/data_labeling/init_dataset_conversion.py
+++ b/script/data_labeling/init_dataset_conversion.py
@@ -118,7 +118,7 @@ def convert_dataset(args, dataset, config):
                     query_type = config["query_format"]["query_type"]
                     format_config = config["query_format"]
                     if query_type == "multiple_choice":
-                        content = prepare_multiple_choice_prompt(item, format_config)
+                        content, _ = prepare_multiple_choice_prompt(item, format_config)
                 
                 if content:  # Only add message if content is not empty
                     formatted_input = content


### PR DESCRIPTION
## Summary
- include correct answer in `prepare_multiple_choice_prompt`
- don't modify dataset items when converting data

## Testing
- `python -m py_compile r2r/evaluate/eval_utils.py script/data_labeling/init_dataset_conversion.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68403367013c8326aa27ab10bb4e54c8