### PR TITLE
[minor] io, checkpoints and eval consistent paths & explicit outputs

### DIFF
--- a/r2r/train/logger.py
+++ b/r2r/train/logger.py
@@ -330,7 +330,7 @@ def print_evaluation_results(
     plt.title("Confusion Matrix")
     plt.ylabel("True Label")
     plt.xlabel("Predicted Label")
-    confusion_matrix_path = os.path.join(output_dir, "confusion_matrix.png")
+    confusion_matrix_path = os.path.join(output_dir, "confusion_matrix_1.png")
     if not os.path.exists(output_dir):
         os.makedirs(output_dir, exist_ok=True)
     plt.savefig(confusion_matrix_path, bbox_inches="tight", dpi=300)
@@ -752,7 +752,12 @@ class TrainingHistory:
         plt.legend()
         
         plt.tight_layout()
+
+        dirpath = os.path.dirname(output_file)
+        if dirpath:
+            os.makedirs(dirpath, exist_ok=True)
         plt.savefig(output_file)
+
         plt.close()
         
         print(f"Training curves saved to {output_file}")

--- a/r2r/train/logger.py
+++ b/r2r/train/logger.py
@@ -270,7 +270,8 @@ def print_evaluation_results(
     y_test: Union[np.ndarray, torch.Tensor],
     predictions: Union[np.ndarray, torch.Tensor],
     probabilities: Union[np.ndarray, torch.Tensor],
-    output_dir: str = "."
+    output_dir: str = ".",
+    filename: str = "confusion_matrix.png"
 ) -> None:
     """Print detailed evaluation results with focus on recall and positive prediction rate."""
     # Print confusion matrix values - convert to numpy arrays if they're tensors
@@ -330,7 +331,7 @@ def print_evaluation_results(
     plt.title("Confusion Matrix")
     plt.ylabel("True Label")
     plt.xlabel("Predicted Label")
-    confusion_matrix_path = os.path.join(output_dir, "confusion_matrix_1.png")
+    confusion_matrix_path = os.path.join(output_dir, filename)
     if not os.path.exists(output_dir):
         os.makedirs(output_dir, exist_ok=True)
     plt.savefig(confusion_matrix_path, bbox_inches="tight", dpi=300)

--- a/r2r/train/optimizer.py
+++ b/r2r/train/optimizer.py
@@ -184,7 +184,9 @@ def calculate_recall(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 def standard_eval_pipeline(
     all_probs,
     all_labels,
-    all_filters
+    all_filters,
+    output_dir: str = ".",
+    filename="confusion_matrix.png"
 ):
     mask = (all_filters == 1)
     filtered_probs = all_probs[mask]
@@ -199,14 +201,14 @@ def standard_eval_pipeline(
     mask = (all_filters == 1)
     default_predictions = (all_probs >= 0.5).astype(int)
     accuracy, precision, recall, f1, positive_rate = print_evaluation_results(
-        all_labels, default_predictions, all_probs
+        all_labels, default_predictions, all_probs, output_dir, filename
     )
 
     print("=" * 60)
     print(f"Using {sum(mask)}/{len(mask)} samples within mismatches.")
     
     print_evaluation_results(
-        filtered_labels, filtered_predictions, filtered_probs
+        filtered_labels, filtered_predictions, filtered_probs, output_dir, filename
     )
 
     return accuracy, precision, recall, f1, positive_rate
@@ -216,7 +218,8 @@ def optimization_pipeline(
     all_labels,
     all_filters,
     optimizing_config,
-    output_dir: str = "."
+    output_dir: str = ".",
+    filename="confusion_matrix_post_opt.png"
 ):  
     mask = (all_filters == 1)
     filtered_probs = all_probs[mask]
@@ -252,7 +255,7 @@ def optimization_pipeline(
 
     predictions = (all_probs >= best_threshold).astype(int)
     accuracy, precision, recall, f1, positive_rate = print_evaluation_results(
-        all_labels, predictions, all_probs, output_dir
+        all_labels, predictions, all_probs, output_dir, filename
     )
 
     # Use filtered data for final evaluation
@@ -260,7 +263,7 @@ def optimization_pipeline(
     print("=" * 60)
     print(f"Using {sum(mask)}/{len(mask)} samples within mismatches.")
     print_evaluation_results(
-        filtered_labels, filtered_predictions, filtered_probs, output_dir
+        filtered_labels, filtered_predictions, filtered_probs, output_dir, filename
     )
 
     # Plot positive rate vs recall curve with the optimal threshold

--- a/resource/default_training_config_qwen3_0_6b.json
+++ b/resource/default_training_config_qwen3_0_6b.json
@@ -68,8 +68,8 @@
     "min_recall": 0.95
   },
   "output": {
-    "output_dir": "resource/default_router_qwen3_1_7b.pt",
-    "checkpoint_dir": "output/checkpoint_qwen3_1_7b",
+    "output_dir": "resource/default_router_qwen3_0_6b.pt",
+    "checkpoint_dir": "output/checkpoint_qwen3_0_6b",
     "model_name": null
   }
 }

--- a/resource/default_training_config_qwen3_4b.json
+++ b/resource/default_training_config_qwen3_4b.json
@@ -69,8 +69,8 @@
     "min_recall": 0.95
   },
   "output": {
-    "output_dir": "resource/default_router_qwen3_1_7b.pt",
-    "checkpoint_dir": "output/checkpoint_qwen3_1_7b",
+    "output_dir": "resource/default_router_qwen3_4b.pt",
+    "checkpoint_dir": "output/checkpoint_qwen3_4b",
     "model_name": null
   }
 }

--- a/resource/default_training_config_qwen_r1.json
+++ b/resource/default_training_config_qwen_r1.json
@@ -68,8 +68,8 @@
     "min_recall": 0.95
   },
   "output": {
-    "output_dir": "resource/default_router.pt",
-    "checkpoint_dir": "output/checkpoint",
+    "output_dir": "resource/default_router_qwen_r1.pt",
+    "checkpoint_dir": "output/checkpoint_qwen_r1",
     "model_name": null
   }
 }

--- a/script/train/train_router.py
+++ b/script/train/train_router.py
@@ -367,7 +367,8 @@ def train_model(
     model = history.load_best_model(model, device)
     
     # Plot training curves
-    history.plot_training_curves(output_dir)
+    training_curves_path = os.path.join(output_dir, "training_curves.png")
+    history.plot_training_curves(training_curves_path)
     
     # Return the model and history object (not just the dictionary)
     return model, history

--- a/script/train/train_router.py
+++ b/script/train/train_router.py
@@ -882,7 +882,12 @@ def main(config: dict, use_wandb: bool = False, validate_model_path: Optional[st
     
     is_skip_optimization = (optimizing_config["type"] == "skip")
     if not is_skip_optimization:
-        pre_opt_accuracy, pre_opt_precision, pre_opt_recall, pre_opt_f1, pre_opt_positive_rate = standard_eval_pipeline(all_probs, all_labels, all_filters)
+        pre_opt_accuracy, pre_opt_precision, pre_opt_recall, pre_opt_f1, pre_opt_positive_rate = standard_eval_pipeline(
+            all_probs,
+            all_labels,
+            all_filters,
+            output_dir = output_dir, 
+            filename = "confusion_matrix_pre_opt.png")
         best_threshold, accuracy, precision, recall, f1, positive_rate, is_succeded = optimization_pipeline(
             all_probs,
             all_labels,
@@ -892,7 +897,7 @@ def main(config: dict, use_wandb: bool = False, validate_model_path: Optional[st
         )  
     else:
         print("Skipping threshold optimization")
-        accuracy, precision, recall, f1, positive_rate = standard_eval_pipeline(all_probs, all_labels, all_filters)
+        accuracy, precision, recall, f1, positive_rate = standard_eval_pipeline(all_probs, all_labels, all_filters, output_dir = output_dir)
         best_threshold = 0.5
         is_succeded = True
 


### PR DESCRIPTION
### Summary
This PR fixes multiple issues in training/evaluation workflows related to inconsistent file paths, checkpoint collisions, and confusion matrix outputs. These changes improve reproducibility, make evaluation outputs more explicit, and prevent errors when training multiple models concurrently.

### Commits
fix: ensure valid plot saving paths in logger
* Create parent directories before saving figures
* Enforce .png extension instead of .pt
* Prevent missing-dir and invalid-format errors

fix: pass explicit training_curves.png path to logger
* Always join output_dir with training_curves.png.
* Ensure training curves are saved with a valid extension.

fix: isolate checkpoints by using unique checkpoint_dir in configs
* Specify dedicated checkpoint_dir per run.
* Avoid checkpoint collisions when multiple models train concurrently.

fix: assign explicit filenames for confusion matrix plots
* Added distinct filenames for pre- and post-optimization confusion matrices.
* Prevent overwriting the default confusion_matrix.png.
* Now outputs: confusion_matrix_pre_opt.png & confusion_matrix_post_opt.png